### PR TITLE
Installation support for Grunt v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,11 @@
-############
-## Windows
-############
-
 # Windows image file caches
 Thumbs.db
-
 # Folder config file
 Desktop.ini
-
-#############
-## My Project
-#############
-
+.DS_Store
+**/__*
+**/.idea
+# project
 node_modules/
 tmp/
-/.idea
-.DS_Store
+**/*.tgz

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Brings externally referenced resources, such as js, css and images, into
 a single file.
 
-For exmample:
+For example:
 
 ````
 <link href="css/style.css?__inline=true" rel="stylesheet" />

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# grunt-inline[![build status](https://secure.travis-ci.org/marcusklaas/grunt-inline.png)](http://travis-ci.org/marcusklaas/grunt-inline)
+# grunt-inline-alt
+
+[![build status](https://secure.travis-ci.org/marcusklaas/grunt-inline-alt.png)](http://travis-ci.org/marcusklaas/grunt-inline-alt)
 
 Brings externally referenced resources, such as js, css and images, into
 a single file.

--- a/package.json
+++ b/package.json
@@ -22,15 +22,15 @@
     "node": ">=0.8.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-htmlmin": "~0.1.3",
-    "grunt-contrib-nodeunit": "~0.1.2"
+    "grunt": ">=0.4.0",
+    "grunt-contrib-clean": ">=0.4.0",
+    "grunt-contrib-htmlmin": ">=0.1.3",
+    "grunt-contrib-nodeunit": ">=0.1.2"
   },
   "dependencies": {
-    "uglify-js": "2.4.1",
-    "datauri": "~0.2.0",
-    "clean-css": "1.1.7"
+    "uglify-js": ">=2.4.1",
+    "datauri": ">=0.2.0",
+    "clean-css": ">=1.1.7"
   },
   "scripts": {
     "test": "grunt test"

--- a/tasks/inline.js
+++ b/tasks/inline.js
@@ -56,10 +56,12 @@ module.exports = function(grunt) {
 	});
 
 	function isRemotePath(url) {
+//grunt.log.write('isRemotePath called -' + url + '\n matches = ' + (url.match(/^'?https?:\/\//) || url.match(/^\/\//)) + '***\n');
 		return url.match(/^'?https?:\/\//) || url.match(/^\/\//);
 	}
 
 	function isBase64Path(url) {
+//grunt.log.write('isBase64Path called -' + url + '\n matches = ' + (url.match(/^'?data.*base64/)) + '^^^\n');
 		return url.match(/^'?data.*base64/);
 	}
 
@@ -87,6 +89,7 @@ module.exports = function(grunt) {
 	    }
 
         var cssReplacement = function(matchedWord, src) {
+//grunt.log.write('cssReplacement :: matchedWord=' + matchedWord + ',imgUrl=' + src + '\n%%%\n');
             if(isRemotePath(src) || (isBase64Path(src)) || src.indexOf(options.tag) == -1) {
 				return matchedWord;
 			}
@@ -189,8 +192,7 @@ module.exports = function(grunt) {
                         return;
             }
             var flag = imgUrl.indexOf(options.tag) != -1;	// urls like "img/bg.png?__inline" will be transformed to base64
-grunt.log.write('urlMatcher :: matchedWord=' + matchedWord + ',imgUrl=' + imgUrl + '\n$$$\n');
-
+//grunt.log.write('urlMatcher :: matchedWord=' + matchedWord + ',imgUrl=' + imgUrl + '\n$$$\n');
 			if((isBase64Path(imgUrl)) || isRemotePath(imgUrl)) {
 				return matchedWord;
 			}

--- a/tasks/inline.js
+++ b/tasks/inline.js
@@ -94,7 +94,6 @@ module.exports = function(grunt) {
 
 			if (grunt.file.exists(inlineFilePath)) {
 				var styleSheetContent = grunt.file.read(inlineFilePath);
-grunt.log.write(inlineFilePath + '\n---\n');
 				var ret = '<style ' + options.inlineTagAttributes.css + '>\n' + cssInlineToHtml(filepath, inlineFilePath, styleSheetContent, relativeTo, options) + '\n</style>';				return ret;
 			} else {
 				grunt.log.error("Couldn't find " + inlineFilePath + '!');


### PR DESCRIPTION
- Edited package.json versions to install with grunt 1.0.1.
- Fixed some (but not all) tests in inline.js.  I didn't fix them all because it looks like they were broken prior to updating dependencies.
- grunt test = 3 of 9 tests fail
- test local installation under grunt 1.0.1 = pass
